### PR TITLE
Update to bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.13.0"
+bevy = "0.14"
 
 [dev-dependencies]
-bevy-inspector-egui = "0.23.2"
-bevy_panorbit_camera = { version = "0.14.0", features = ["bevy_egui"] }
-bevy_screen_diagnostics = "0.5.0"
+bevy-inspector-egui = "0.25"
+bevy_panorbit_camera = { version = "0.19", features = ["bevy_egui"] }
+bevy_screen_diagnostics = "0.6"
 rand = "0.8.5"

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -12,7 +12,7 @@ use bevy::{
     prelude::*,
 };
 use bevy_contact_projective_decals::{decal_mesh_quad, DecalBundle, DecalMaterial, DecalPlugin};
-use rand::{seq::SliceRandom, thread_rng, Rng};
+use rand::{thread_rng, Rng};
 fn main() {
     App::new()
         .add_plugins((

--- a/examples/room.rs
+++ b/examples/room.rs
@@ -108,7 +108,7 @@ fn setup(
         decal_material: decal_materials.add(ExtendedMaterial::<StandardMaterial, DecalMaterial> {
             base: StandardMaterial {
                 base_color_texture: Some(asset_server.load("blast.png")),
-                base_color: Color::RED,
+                base_color: Color::Srgba(Srgba::RED),
                 alpha_mode: AlphaMode::Blend,
                 ..default()
             },
@@ -125,7 +125,7 @@ fn setup(
         decal_material: decal_materials.add(ExtendedMaterial::<StandardMaterial, DecalMaterial> {
             base: StandardMaterial {
                 base_color_texture: Some(asset_server.load("blast.png")),
-                base_color: Color::RED,
+                base_color: Color::Srgba(Srgba::RED),
                 alpha_mode: AlphaMode::Blend,
                 ..default()
             },
@@ -142,7 +142,7 @@ fn setup(
         decal_material: decal_materials.add(ExtendedMaterial::<StandardMaterial, DecalMaterial> {
             base: StandardMaterial {
                 base_color_texture: Some(asset_server.load("blast.png")),
-                base_color: Color::RED,
+                base_color: Color::Srgba(Srgba::RED),
                 alpha_mode: AlphaMode::Blend,
                 ..default()
             },
@@ -159,7 +159,7 @@ fn setup(
         decal_material: decal_materials.add(ExtendedMaterial::<StandardMaterial, DecalMaterial> {
             base: StandardMaterial {
                 base_color_texture: Some(asset_server.load("blast.png")),
-                base_color: Color::RED,
+                base_color: Color::Srgba(Srgba::RED),
                 alpha_mode: AlphaMode::Blend,
                 ..default()
             },
@@ -176,7 +176,7 @@ fn setup(
         decal_material: decal_materials.add(ExtendedMaterial::<StandardMaterial, DecalMaterial> {
             base: StandardMaterial {
                 base_color_texture: Some(asset_server.load("blast.png")),
-                base_color: Color::RED,
+                base_color: Color::Srgba(Srgba::RED),
                 alpha_mode: AlphaMode::Blend,
                 ..default()
             },

--- a/examples/static.rs
+++ b/examples/static.rs
@@ -84,7 +84,7 @@ fn setup(
         decal_material: decal_materials.add(ExtendedMaterial::<StandardMaterial, DecalMaterial> {
             base: StandardMaterial {
                 base_color_texture: Some(asset_server.load("blast.png")),
-                base_color: Color::RED,
+                base_color: Color::Srgba(Srgba::RED),
                 alpha_mode: AlphaMode::Blend,
                 ..default()
             },

--- a/src/decal.rs
+++ b/src/decal.rs
@@ -7,7 +7,7 @@ use bevy::{
     },
     prelude::*,
     render::{
-        mesh::MeshVertexBufferLayout,
+        mesh::MeshVertexBufferLayoutRef,
         render_resource::{
             AsBindGroup, CompareFunction, RenderPipelineDescriptor, ShaderRef,
             SpecializedMeshPipelineError,
@@ -31,6 +31,7 @@ impl Plugin for DecalPlugin {
 pub fn decal_mesh_quad(normal: Vec3) -> Mesh {
     Rectangle::from_size(Vec2::ONE)
         .mesh()
+        .build()
         .rotated_by(Quat::from_rotation_arc(Vec3::Z, normal))
         .with_generated_tangents()
         .unwrap()
@@ -57,7 +58,7 @@ impl MaterialExtension for DecalMaterial {
     fn specialize(
         _pipeline: &MaterialExtensionPipeline,
         descriptor: &mut RenderPipelineDescriptor,
-        _layout: &MeshVertexBufferLayout,
+        _layout: &MeshVertexBufferLayoutRef,
         _key: MaterialExtensionKey<Self>,
     ) -> Result<(), SpecializedMeshPipelineError> {
         if let Some(label) = &mut descriptor.label {

--- a/src/decal.wgsl
+++ b/src/decal.wgsl
@@ -41,7 +41,7 @@ struct DecalInformation {
 fn decalize(in: VertexOutput, is_front: bool, depth_fade_factor: f32) -> DecalInformation {
 
     let v_ray = view.world_position - in.world_position.xyz;
-    let model = bevy_pbr::mesh_functions::get_model_matrix(in.instance_index);
+    let model = bevy_pbr::mesh_functions::get_world_from_local(in.instance_index);
     let scale = (model * vec4(1.0, 1.0, 1.0, 0.0)).xyz;
 
     // view vector


### PR DESCRIPTION
Updates the API to use Bevy 0.14, as well as updating the rest of the dependencies. All examples are running successfully.